### PR TITLE
use RFC 1738 compatible rawurldecode function to actually fix signature

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -113,7 +113,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             if (strcasecmp($key, 'Brq_signature') === 0) {
                 continue;
             }
-            $str .= $key.'='.urldecode($value);
+            $str .= $key.'='.rawurldecode($value);
         }
 
         return sha1($str.$this->getSecretKey());


### PR DESCRIPTION
Emailadresses are allowed to have + in them and these should not be urldecoded.

This does not fix other urldecoding problems with chars that are allowed in emailaddresses and also urldecodable, but those are rarer ( I hope )